### PR TITLE
All semver prefixes that start with "v"

### DIFF
--- a/lib/omnibus/build_version.rb
+++ b/lib/omnibus/build_version.rb
@@ -179,9 +179,9 @@ module Omnibus
     # @return [nil] if no pre-release tag was found
     def prerelease_tag
       prerelease_regex = if commits_since_tag > 0
-                           /^\d+\.\d+\.\d+(?:-|\.)([0-9A-Za-z.-]+)-\d+-g[0-9a-f]+$/
+                           /^v?\d+\.\d+\.\d+(?:-|\.)([0-9A-Za-z.-]+)-\d+-g[0-9a-f]+$/
                          else
-                           /^\d+\.\d+\.\d+(?:-|\.)([0-9A-Za-z.-]+)$/
+                           /^v?\d+\.\d+\.\d+(?:-|\.)([0-9A-Za-z.-]+)$/
                          end
       match = prerelease_regex.match(git_describe)
       match ? match[1] : nil
@@ -267,8 +267,13 @@ module Omnibus
     #
     # @todo Compute this once and store the result in an instance variable
     def version_composition
-      version_regexp = /^(\d+)\.(\d+)\.(\d+)/
-      version_regexp.match(git_describe)[1..3]
+      version_regexp = /^v?(\d+)\.(\d+)\.(\d+)/
+
+      if match = version_regexp.match(git_describe)
+        match[1..3]
+      else
+        raise "Invalid semver tag `#{git_describe}'!"
+      end
     end
   end
 end

--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -150,6 +150,7 @@ module Omnibus
       options[:read_timeout] = Omnibus::Config.fetcher_read_timeout
 
       progress_bar = ProgressBar.create(
+        output: $stdout,
         format: '%e %B %p%% (%r KB/sec)',
         rate_scale: ->(rate) { rate / 1024 },
       )

--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -16,6 +16,7 @@
 
 require 'fileutils'
 require 'open-uri'
+require 'ruby-progressbar'
 
 module Omnibus
   class NetFetcher < Fetcher
@@ -147,6 +148,13 @@ module Omnibus
       end
 
       options[:read_timeout] = Omnibus::Config.fetcher_read_timeout
+
+      progress_bar = ProgressBar.create(
+        format: '%e %B %p%% (%r KB/sec)',
+        rate_scale: ->(rate) { rate / 1024 },
+      )
+      options[:content_length_proc] = ->(total) { progress_bar.total = total }
+      options[:progress_proc] = ->(step) { progress_bar.progress = step }
 
       file = open(download_url, options)
       FileUtils.cp(file.path, downloaded_file)

--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -21,12 +21,13 @@ Gem::Specification.new do |gem|
   gem.test_files = gem.files.grep(/^(test|spec|features)\//)
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'chef-sugar',      '~> 2.2'
-  gem.add_dependency 'cleanroom',       '~> 1.0'
-  gem.add_dependency 'mixlib-shellout', '~> 1.4'
-  gem.add_dependency 'ohai',            '~> 7.2'
+  gem.add_dependency 'chef-sugar',       '~> 2.2'
+  gem.add_dependency 'cleanroom',        '~> 1.0'
+  gem.add_dependency 'mixlib-shellout',  '~> 1.4'
+  gem.add_dependency 'ohai',             '~> 7.2'
+  gem.add_dependency 'ruby-progressbar', '~> 1.7'
   gem.add_dependency 'uber-s3'
-  gem.add_dependency 'thor',            '~> 0.18'
+  gem.add_dependency 'thor',             '~> 0.18'
 
   gem.add_development_dependency 'bundler'
   gem.add_development_dependency 'artifactory', '~> 2.0'

--- a/spec/functional/fetchers/net_fetcher_spec.rb
+++ b/spec/functional/fetchers/net_fetcher_spec.rb
@@ -2,16 +2,16 @@ require 'spec_helper'
 
 module Omnibus
   describe NetFetcher do
-    include_examples 'a software'
+    include_examples 'a software', 'zlib'
 
-    let(:source_url) { 'http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz' }
-    let(:source_md5) { '00b516f4704d4a7cb50a1d97e6e8e15b' }
+    let(:source_url) { 'http://downloads.sourceforge.net/project/libpng/zlib/1.2.8/zlib-1.2.8.tar.gz' }
+    let(:source_md5) { '44d667c142d7cda120332623eab69f40' }
     let(:source) do
       { url: source_url, md5: source_md5 }
     end
 
     let(:downloaded_file) { subject.send(:downloaded_file) }
-    let(:extracted) { File.join(source_dir, 'bzip2-1.0.6') }
+    let(:extracted) { File.join(source_dir, 'zlib-1.2.8') }
 
     subject { described_class.new(software) }
 

--- a/spec/functional/fetchers/net_fetcher_spec.rb
+++ b/spec/functional/fetchers/net_fetcher_spec.rb
@@ -13,6 +13,8 @@ module Omnibus
     let(:downloaded_file) { subject.send(:downloaded_file) }
     let(:extracted) { File.join(source_dir, 'zlib-1.2.8') }
 
+    let(:fetch!) { capture_stdout { subject.fetch } }
+
     subject { described_class.new(software) }
 
     describe '#fetch_required?' do
@@ -23,7 +25,7 @@ module Omnibus
       end
 
       context 'when the file is downloaded' do
-        before { subject.fetch }
+        before { fetch! }
 
         context 'when the checksum is different' do
           it 'return true' do
@@ -47,7 +49,7 @@ module Omnibus
     end
 
     describe '#clean' do
-      before { subject.fetch }
+      before { fetch! }
 
       context 'when the project directory exists' do
         before do
@@ -77,7 +79,7 @@ module Omnibus
 
     describe '#fetch' do
       it 'downloads the file' do
-        subject.fetch
+        fetch!
         expect(downloaded_file).to be_a_file
       end
 
@@ -85,12 +87,12 @@ module Omnibus
         let(:source_md5) { 'bad01234checksum' }
 
         it 'raises an exception' do
-          expect { subject.fetch }.to raise_error(ChecksumMismatch)
+          expect { fetch! }.to raise_error(ChecksumMismatch)
         end
       end
 
       it 'extracts the file' do
-        subject.fetch
+        fetch!
         expect(extracted).to be_a_directory
       end
 
@@ -99,7 +101,7 @@ module Omnibus
         let(:source_md5) { '369efc3a19b9118cdf51c7e87a34f266' }
 
         it 'downloads the file' do
-          subject.fetch
+          fetch!
           expect(downloaded_file).to be_a_file
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,9 @@ RSpec.configure do |config|
   require_relative 'support/ohai_helpers'
   config.include(Omnibus::RSpec::OhaiHelpers)
 
+  require_relative 'support/output_helpers'
+  config.include(Omnibus::RSpec::OutputHelpers)
+
   require_relative 'support/path_helpers'
   config.include(Omnibus::RSpec::PathHelpers)
 

--- a/spec/support/output_helpers.rb
+++ b/spec/support/output_helpers.rb
@@ -1,0 +1,29 @@
+module Omnibus
+  module RSpec
+    module OutputHelpers
+      #
+      # Capture stdout within this block.
+      #
+      def capture_stdout(&block)
+        old = $stdout
+        $stdout = fake = StringIO.new
+        yield
+        fake.string
+      ensure
+        $stdout = old
+      end
+
+      #
+      # Capture stderr within this block.
+      #
+      def capture_stderr(&block)
+        old = $stderr
+        $stderr = fake = StringIO.new
+        yield
+        fake.string
+      ensure
+        $stderr = old
+      end
+    end
+  end
+end

--- a/spec/unit/build_version_spec.rb
+++ b/spec/unit/build_version_spec.rb
@@ -88,6 +88,16 @@ module Omnibus
         its(:commits_since_tag) { should == 0 }
         its(:prerelease_version?) { should be_truthy }
       end
+
+      # v-prefixed tag
+      context "v1.2.3-beta2" do
+        let(:git_describe) { "v1.2.3-beta2" }
+        its(:version_tag) { should == "1.2.3" }
+        its(:prerelease_tag) { should == "beta2" }
+        its(:git_sha_tag) { should be(nil) }
+        its(:commits_since_tag) { should eq(0) }
+        its(:prerelease_version?) { should be(true) }
+      end
     end
 
     describe 'semver output' do


### PR DESCRIPTION
:tada: Happy New Year!

I realize this is a special case, but `rake release` and many other Ruby-related tools automatically prefix a "v" onto tags.

This also raises a more semantic error when a match fails in the `version_composition` (otherwise it's a fun "undefined method :[] for nil").

/cc @schisamo @danielsdeleo 