### PR TITLE
Do not memoize current_revision to avoid returning incorrect data

### DIFF
--- a/lib/omnibus/fetchers/git_fetcher.rb
+++ b/lib/omnibus/fetchers/git_fetcher.rb
@@ -135,7 +135,7 @@ module Omnibus
     # @return [String]
     #
     def current_revision
-      @current_revision ||= git('rev-parse HEAD').stdout.strip
+      git('rev-parse HEAD').stdout.strip
     rescue CommandFailed
       nil
     end

--- a/spec/functional/fetchers/git_fetcher_spec.rb
+++ b/spec/functional/fetchers/git_fetcher_spec.rb
@@ -154,6 +154,14 @@ module Omnibus
       it 'includes the revision' do
         expect(subject.version_for_cache).to eq("revision:#{revision}")
       end
+
+      it "does not returned cached revision after fetching" do
+        before_fetch = subject.version_for_cache
+        subject.fetch
+        after_fetch = revision
+        expect(subject.version_for_cache).to eq("revision:#{after_fetch}")
+        expect(subject.version_for_cache).not_to eq("revision:#{before_fetch}")
+      end
     end
   end
 end


### PR DESCRIPTION
After a fetch (and other operations), the current revision may
change. Calls to functions such as version_for_cache should reflect
this change.  Memoizing current_revision was previously causing
version_for_cache to return the pre-fetch revision of the software,
leading us to erroneously restore an older revision from the cache.